### PR TITLE
Update description of edge_average

### DIFF
--- a/src/graph_tool/stats/__init__.py
+++ b/src/graph_tool/stats/__init__.py
@@ -250,7 +250,7 @@ def vertex_average(g, deg):
 
 def edge_average(g, eprop):
     """
-    Return the average of the given degree or vertex property.
+    Return the average of the given edge property.
 
     Parameters
     ----------


### PR DESCRIPTION
The description of "edge_average" incorrectly repeats the description of "vertex_average", as "edge_average" is unable to calculate averages of degrees or vertex properties.